### PR TITLE
:sparkles:: Add Renovate presets

### DIFF
--- a/.github/workflows/merge_group,pull_request.renovate.validate.yaml
+++ b/.github/workflows/merge_group,pull_request.renovate.validate.yaml
@@ -1,0 +1,39 @@
+---
+name: 🔄 Validate Renovate Configuration
+
+on:
+  merge_group: {}
+  pull_request:
+    paths: ["*.json"]
+
+concurrency:
+  group: ${{ github.action }}-${{ github.event.pull_request.id }}
+  cancel-in-progress: true
+permissions: {}
+
+jobs:
+  validate:
+    name: ✅ Validate Renovate config
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: ⬇️ Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: lts/*
+
+      - name: 📦 Install renovate
+        run: npm install -g renovate
+
+      - name: 🔍 Validate Renovate config files
+        run: |
+          find . -maxdepth 1 -name "*.json" -type f ! -name ".devcontainer.json" ! -name "github-actions.json" -print0 | xargs -0 -I{} sh -c '
+            echo "::group::Validating Renovate configuration {}"
+            echo "Validating {}"
+            renovate-config-validator {} || exit 1
+            echo "::endgroup::"
+          '

--- a/README.md
+++ b/README.md
@@ -1,16 +1,46 @@
 <!-- markdownlint-disable MD033 -->
 <h1 align="center">
-    chezmoi.sh - Template repository for most chezmoi.sh projects
+    <img width="100" height="100" src="docs/assets/icon/renovate.png" alt="Renovate Logo"/>
+    <br/><br/>
+    <i>chezmoi.sh</i> - Renovate configuration presets
 </h1>
 
-<h4 align="center">Template repository for all `chezmoi.sh` projects</h4>
+<h4 align="center">Collection of <a href="https://renovatebot.com/">Renovate</a> configuration presets for this organization.</h4>
 
 <div align="center">
 
-[![License](https://img.shields.io/badge/license-Apache-2.0-blue?logo=git&logoColor=white)](LICENSE)
+[ ![License](https://img.shields.io/github/license/chezmoi-sh/renovate-config?logo=git&logoColor=white&logoWidth=20) ](LICENSE)
+[ ![Pending dependencies](https://img.shields.io/github/issues-pr/chezmoi-sh/renovate-config/type:%20dependencies?label=dependencies&logo=renovatebot&logoWidth=20&style=flat)
+](https://github.com/chezmoi-sh/renovate-config/pulls?q=is%3Apr+is%3Aopen+label%3A%22type%3A+dependencies%22)
 
 </div>
 
 ---
 
-## 📚 Table of Contents
+<!-- markdownlint-enable MD033 -->
+
+## Renovate Presets
+
+This repository contains all Renovate presets used within the chezmoi-sh organization.
+
+### [Why Use Presets?](https://docs.renovatebot.com/key-concepts/presets/)
+
+Presets provide several benefits:
+
+- **Simplified Setup**: Configure Renovate with optimal default settings.
+- **Reduced Duplication**: Avoid repetitive configurations across multiple repositories.
+- **Enhanced Collaboration**: Share standardized configurations across teams and projects.
+- **Extensibility**: Build upon existing configurations by extending them with custom rules.
+
+### Managing Configurations Across Multiple Repositories
+
+For organizations managing Renovate across numerous repositories, creating a global preset configuration is highly recommended. By extending this global preset in each repository, you centralize and streamline your configuration management. This approach ensures consistency and simplifies updates, as all global settings are maintained in a single file within a dedicated repository.
+
+## List of existing presets
+
+- `github>chezmoi-sh/renovate-config`: default Renovate configuration.
+- `github>chezmoi-sh/renovate-config:gitmoji`: make each Renovate commit compatible with [Gitmoji](https://gitmoji.dev/).
+- `github>chezmoi-sh/renovate-config:github-actions({{schedule}})`: groups all GitHub-actions upgrades together to reduce the number of PRs.
+  - `{{schedule}}`: defines when GitHub actions upgrade should be scheduled. Must be one of `daily`, `earlyMondays`, `monthly`, `nonOfficeHours`, `quarterly`, `weekdays`, `weekends`, `weekly` or `yearly`
+- `github>chezmoi-sh/renovate-config:automerge@{{type}}`: automatically merge PRs when all checks are passing.
+  - `{{type}}`: defines which type of PRs should be automatically merged. Must be one of `all`, `minor` or `patch`

--- a/automerge@all.json
+++ b/automerge@all.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    ":automergeMinor",
+    ":automergePatch",
+    ":automergePr",
+    ":automergeRequireAllStatusChecks",
+    ":combinePatchMinorReleases"
+  ]
+}

--- a/automerge@minor.json
+++ b/automerge@minor.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    ":automergeMinor",
+    ":automergePr",
+    ":automergeRequireAllStatusChecks"
+  ]
+}

--- a/automerge@patch.json
+++ b/automerge@patch.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    ":automergePatch",
+    ":automergePr",
+    ":automergeRequireAllStatusChecks"
+  ]
+}

--- a/default.json
+++ b/default.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    ":automergeDigest",
+    ":automergeLinters",
+    ":automergeRequireAllStatusChecks",
+    ":automergeTesters",
+    ":combinePatchMinorReleases",
+    ":dependencyDashboard",
+    ":enableVulnerabilityAlerts",
+    ":gitSignOff",
+    ":ignoreModulesAndTests",
+    ":ignoreUnstable",
+    ":labels(type: dependencies)",
+    ":maintainLockFilesMonthly",
+    ":prConcurrentLimitNone",
+    ":prHourlyLimitNone",
+    ":prImmediately",
+    ":renovatePrefix",
+    ":semanticCommitScope(deps)",
+    ":separateMultipleMajorReleases",
+    "customManagers:dockerfileVersions",
+    "helpers:pinGitHubActionDigests"
+  ]
+}

--- a/github-actions.json
+++ b/github-actions.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "extends": ["schedule:{{arg0}}"],
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "GitHub actions",
+      "groupSlug": "github-actions"
+    }
+  ]
+}

--- a/gitmoji.json
+++ b/gitmoji.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [":semanticCommits"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["*"],
+      "semanticCommitType": ":arrow_up: "
+    },
+    {
+      "matchDepTypes": ["dependencies", "require"],
+      "semanticCommitType": ":green_heart: "
+    }
+  ],
+  "semanticCommitType": ":arrow_up: "
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,9 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "config:recommended",
-        "github>belug-apps/renovate-config:gitmoji"
-    ]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "github>chezmoi-sh/renovate-config:automerge@all",
+    "github>chezmoi-sh/renovate-config:github-actions",
+    "github>chezmoi-sh/renovate-config:gitmoji"
+  ]
 }


### PR DESCRIPTION
This pull request introduces a new workflow for validating Renovate configurations, updates the README to reflect the new purpose of the repository, and adds several Renovate configuration presets. The most important changes include the addition of a GitHub Actions workflow for validation, updates to the README, and the creation of various Renovate configuration files.

### New GitHub Actions Workflow:
* Added a new workflow file `.github/workflows/merge_group,pull_request.renovate.validate.yaml` to validate Renovate configuration files on merge group and pull request events. ([.github/workflows/merge_group,pull_request.renovate.validate.yamlR1-R39](diffhunk://#diff-5948eebe77e835405d9a3edd16dd529e0123baff58671447bec95c3675bf86e1R1-R39))

### README Updates:
* Updated `README.md` to reflect the new purpose of the repository as a collection of Renovate configuration presets, including a new logo and additional sections explaining the benefits of using presets.

### Renovate Configuration Presets:
* Added `automerge@all.json` to automatically merge minor and patch updates when all status checks pass.
* Added `automerge@minor.json` to automatically merge minor updates when all status checks pass.
* Added `automerge@patch.json` to automatically merge patch updates when all status checks pass.
* Added `default.json` with a comprehensive set of default Renovate configurations.
* Added `github-actions.json` to group GitHub Actions updates based on a specified schedule.
* Added `gitmoji.json` to ensure Renovate commits follow Gitmoji conventions.

### Configuration Update:
* Updated `renovate.json` to extend new configuration presets from the `chezmoi-sh` organization.